### PR TITLE
Update FREE badge color to violet in event card

### DIFF
--- a/resources/views/components/event-card.blade.php
+++ b/resources/views/components/event-card.blade.php
@@ -19,7 +19,7 @@
                         <h2 class="text-xl font-bold flex items-center">
                             <span class="mr-1">{{ $event->name }}</span>
                             @if ($event->price == 0)
-                                <span class="text-xs text-white py-1 px-2 rounded shadow uppercase font-bold bg-purple-600">
+                                <span class="text-xs text-white py-1 px-2 rounded shadow uppercase font-bold bg-violet-600">
                                     FREE
                                 </span>
                             @endif
@@ -28,7 +28,7 @@
                         <h2 class="text-xl font-bold flex items-center">
                             <a href="{{ route('events.single', ['event' => $event->id]) }}" class="mr-1">{{ $event->name }}</a>
                             @if ($event->price == 0)
-                                <span class="text-xs text-white py-1 px-2 rounded shadow uppercase font-bold bg-purple-600">
+                                <span class="text-xs text-white py-1 px-2 rounded shadow uppercase font-bold bg-violet-600">
                                     FREE
                                 </span>
                             @endif

--- a/resources/views/livewire/display-event.blade.php
+++ b/resources/views/livewire/display-event.blade.php
@@ -205,7 +205,7 @@
                     <div class="flex items-center justify-between">
                         <div>
                             @if(is_null($event->price) || $event->price == 0)
-                                <span class="text-green-500 font-bold text-xl">FREE</span>
+                                <span class="text-violet-600 font-bold text-xl">FREE</span>
                             @else
                                 <span class="text-yellow-400 font-bold text-xl">
                                     <span x-text="symbols[currentCurrency]"></span>


### PR DESCRIPTION
Change the color of the FREE badge from purple to violet for better visibility and consistency across the event display.