### PR TITLE
Add event starting notifications and ticket assignment updates

### DIFF
--- a/app/Console/Commands/AlertStartingEvents.php
+++ b/app/Console/Commands/AlertStartingEvents.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class AlertStartingEvents extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:alert-starting-events';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Alert attendees that their event is starting soon';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $eventsToday = Event::whereBetween('start_time', [
+            Carbon::today(),
+            Carbon::tomorrow()->subSecond()
+        ])->get();
+
+        foreach ($eventsToday as $event) {
+            $event->sendStartingNotification();
+        }
+    }
+}

--- a/app/Mail/EventStartingSoonMail.php
+++ b/app/Mail/EventStartingSoonMail.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Attendee;
+use App\Models\Event;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class EventStartingSoonMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Event $event, public Attendee $attendee)
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: config('mail.from.address'),
+            to: [
+                new Address($this->attendee->user->email, $this->attendee->user->name),
+            ],
+            subject: 'An event you are attending is starting soon!',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.event-starting-soon-mail',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/resources/views/livewire/assign-tickets.blade.php
+++ b/resources/views/livewire/assign-tickets.blade.php
@@ -3,7 +3,8 @@
         <h2 class="text-xl font-bold mb-4">Assign your tickets</h2>
         <p>You have purchased {{ $nbrTickets }} tickets for this event.</p>
         @if ($nbrTicketsAssignedToUser > 1)
-            <p class="mb-4 text-red-500">Assign at least {{ $nbrTickets-1 }} ticket(s) to other users.</p>
+            {{-- <p class="mb-4 text-red-500">Assign at least {{ $nbrTickets-1 }} ticket(s) to other users.</p> --}}
+            <p class="mb-4">Use this form to assign the tickets to the correct user.</p>
         @else
             <p class="mb-4 text-green-500">All tickets are correctly assigned.</p>
         @endif

--- a/resources/views/livewire/display-event.blade.php
+++ b/resources/views/livewire/display-event.blade.php
@@ -130,14 +130,14 @@
                                     Unattend
                                 </button>
                             @endif
-                            @if ($numTicketsAssignedToUser <= 1)
+                            {{-- @if ($numTicketsAssignedToUser <= 1) --}}
                                 <button class="btn btn-primary flex-1"
                                         wire:click.prevent="downloadTicket()">
                                     Download {{ $userTicketsCount }} Ticket{{ $userTicketsCount > 1 ? 's' : '' }}
                                 </button>
-                            @else
+                            {{-- @else
                                 <div class="bg-red-500 text-white p-2 w-full text-center">You must assign your tickets</div>
-                            @endif
+                            @endif --}}
                         </div>
                     @endif
 

--- a/resources/views/livewire/list-user-events.blade.php
+++ b/resources/views/livewire/list-user-events.blade.php
@@ -55,17 +55,17 @@
                                 wire:confirm="Are you sure?">Unattend</button>
                         @endif
 
-                        @if ($numTicketsAssignedToUser <= 1)
+                        {{-- @if ($numTicketsAssignedToUser <= 1) --}}
                             <button class="btn btn-primary btn-sm"
                                 wire:click.prevent="downloadTicket({{ $event->id }})"
                             >Download {{ $userTicketsCount }} Ticket{{ $userTicketsCount > 1 ? 's' : '' }}</button>
-                        @else
+                        {{-- @else --}}
                             {{-- There are more than 1 ticket (attendee) assigned to the current user. User needs to assign tickets before downloading --}}
-                            <div class="text-right">
+                            {{-- <div class="text-right">
                                 <p class="text-red-500 font-bold">You must assign your tickets!</p>
                                 <a href="{{ route('events.single', ['event' => $event->id]) }}" class="btn btn-primary btn-sm inline-block">Assign</a>
-                            </div>
-                        @endif
+                            </div> --}}
+                        {{-- @endif --}}
                     </div>
                 @endif
             @endslot

--- a/resources/views/mail/event-starting-soon-mail.blade.php
+++ b/resources/views/mail/event-starting-soon-mail.blade.php
@@ -1,0 +1,16 @@
+<x-mail::message>
+### The event is starting soon:
+# {{ $event->name }}
+
+Hello {{ $attendee->user->name }},
+
+This event that you are attending is starting soon.<br>
+Go to our website to download your ticket(s).
+
+<x-mail::button :url="url('/events/' . $event->id)" color="purple">
+Visit event detail page
+</x-mail::button>
+
+Thanks,<br>
+[{{ config('app.name') }}]({{ url('/') }})
+</x-mail::message>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,12 @@
 <?php
 
+use App\Console\Commands\AlertStartingEvents;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command(AlertStartingEvents::class)->dailyAt('5:00');;


### PR DESCRIPTION
Introduce a command for alerting attendees about upcoming events and a corresponding email notification. Remove the requirement for users to assign all purchased tickets before downloading them. Update the scheduling for the alert command to run daily.